### PR TITLE
Add Windows Legacy support and bump velociraptor to v0.76

### DIFF
--- a/generaptor/command/update.py
+++ b/generaptor/command/update.py
@@ -6,7 +6,7 @@ from ..helper.http import http_download, http_set_proxies
 from ..helper.logging import get_logger
 
 _LOGGER = get_logger('command.update')
-_FETCH_TAG_DEFAULT = 'v0.75'
+_FETCH_TAG_DEFAULT = 'v0.76'
 
 
 def _update_cmd(args):

--- a/generaptor/concept/distribution.py
+++ b/generaptor/concept/distribution.py
@@ -12,6 +12,8 @@ class Architecture(Enum):
     AMD64 = 'amd64'
     AMD64_MUSL = 'amd64-musl'
     ARM64 = 'arm64'
+    X86_LEGACY = '386-legacy'
+    AMD64_LEGACY = 'amd64-legacy'
 
 
 class OperatingSystem(Enum):
@@ -59,6 +61,14 @@ SUPPORTED_DISTRIBUTIONS = [
     ),
     Distribution(
         arch=Architecture.AMD64,
+        opsystem=OperatingSystem.WINDOWS,
+    ),
+    Distribution(
+        arch=Architecture.X86_LEGACY,
+        opsystem=OperatingSystem.WINDOWS,
+    ),
+    Distribution(
+        arch=Architecture.AMD64_LEGACY,
         opsystem=OperatingSystem.WINDOWS,
     ),
     Distribution(


### PR DESCRIPTION
**Changes**

- Add `windows-386-legacy` distribution
- Add `windows-amd64-legacy` distribution
- Bump Velociraptor default version to [v0.76](https://github.com/Velocidex/velociraptor/releases/tag/v0.76)