### PR TITLE
Bump Velociraptor to v0.77 & fixes 

### DIFF
--- a/generaptor/command/get_rules.py
+++ b/generaptor/command/get_rules.py
@@ -17,6 +17,9 @@ def _get_rules_cmd(args):
     if args.profile:
         profile_set = get_profile_set(args.cache, args.config, opsystem)
         profile = profile_set.by_name.get(args.profile)
+        if not profile:
+            _LOGGER.error("cannot find profile: %s", args.profile)
+            return
         rule_set = get_rule_set_from_targets(
             args.cache, args.config, opsystem, profile.targets
         )

--- a/generaptor/command/new_profile.py
+++ b/generaptor/command/new_profile.py
@@ -1,5 +1,7 @@
 """new-profile command"""
 
+from uuid import UUID
+
 from ..concept import Profile
 from ..helper.json import dump_json
 from ..helper.logging import get_logger
@@ -8,7 +10,7 @@ _LOGGER = get_logger('command.new_profile')
 
 
 def _new_profile_cmd(args):
-    profile = Profile(name=args.name, targets=args.targets)
+    profile = Profile(name=args.name, targets=set(args.targets))
     print(dump_json(profile.to_dict()))
 
 
@@ -17,6 +19,6 @@ def setup_cmd(cmd):
     new_profile = cmd.add_parser('new-profile', help="generate a new profile")
     new_profile.add_argument('name', help="profile name")
     new_profile.add_argument(
-        'targets', nargs='+', metavar='target', help="profile targets"
+        'targets', nargs='+', type=UUID, metavar='target', help="profile targets"
     )
     new_profile.set_defaults(func=_new_profile_cmd)

--- a/generaptor/command/new_target.py
+++ b/generaptor/command/new_target.py
@@ -1,5 +1,7 @@
 """new-target command"""
 
+from uuid import UUID
+
 from ..concept import Target
 from ..helper.json import dump_json
 from ..helper.logging import get_logger
@@ -8,7 +10,7 @@ _LOGGER = get_logger('command.new_target')
 
 
 def _new_target_cmd(args):
-    target = Target(name=args.name, rules=args.rules)
+    target = Target(name=args.name, rules=set(args.rules))
     print(dump_json(target.to_dict()))
 
 
@@ -17,6 +19,6 @@ def setup_cmd(cmd):
     new_target = cmd.add_parser('new-target', help="generate a new target")
     new_target.add_argument('name', help="target name")
     new_target.add_argument(
-        'rules', nargs='+', metavar='rule', help="target rules"
+        'rules', nargs='+', type=UUID, metavar='rule', help="target rules"
     )
     new_target.set_defaults(func=_new_target_cmd)

--- a/generaptor/command/update.py
+++ b/generaptor/command/update.py
@@ -6,7 +6,7 @@ from ..helper.http import http_download, http_set_proxies
 from ..helper.logging import get_logger
 
 _LOGGER = get_logger('command.update')
-_FETCH_TAG_DEFAULT = 'v0.76'
+_FETCH_TAG_DEFAULT = 'v0.77'
 
 
 def _update_cmd(args):

--- a/generaptor/concept/collector.py
+++ b/generaptor/concept/collector.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from io import StringIO
 from pathlib import Path
 from platform import system
-from subprocess import run
+from subprocess import CalledProcessError, run
 
 from ..__version__ import version
 from ..helper.crypto import Certificate, fingerprint, pem_string
@@ -122,6 +122,11 @@ class Collector:
             str(output_binary),
         ]
         _LOGGER.info("spawning subprocess: %s", argv)
-        run(argv, check=True)
+        try:
+            run(argv, check=True)
+        except CalledProcessError as exc:
+            _LOGGER.critical("repack failed (exit %d)", exc.returncode)
+            output_config.unlink(missing_ok=True)
+            return None
         _LOGGER.info("release binary written to: %s", output_binary)
         return output_binary, output_config

--- a/generaptor/concept/target_set.py
+++ b/generaptor/concept/target_set.py
@@ -109,8 +109,8 @@ class TargetSet:
             targets = multiselect(
                 "Pick one or more collection targets",
                 [
-                    Option(label=target.name, value=target)
-                    for name, target in self.by_name.items()
+                    Option(label=target.name, value=target.name)
+                    for target in self.by_name.values()
                 ],
             )
         by_guid = {}
@@ -120,9 +120,11 @@ class TargetSet:
             if not target:
                 _LOGGER.warning("skipped unknown target: %s", key)
                 continue
-            by_guid.update(
-                {guid: rule_set.by_guid[guid] for guid in target.rules}
-            )
+            for guid in target.rules:
+                if guid not in rule_set.by_guid:
+                    _LOGGER.warning("skipped missing rule: %s", guid)
+                    continue
+                by_guid[guid] = rule_set.by_guid[guid]
             _LOGGER.info(
                 "select %s (%d rules)", target.name, len(target.rules)
             )

--- a/generaptor/main.py
+++ b/generaptor/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Application"""
 
+from sys import exit as sys_exit
 from argparse import ArgumentParser
 
 from .__version__ import version
@@ -42,7 +43,7 @@ def app():
         _LOGGER.error(
             "cache update is needed, please run 'update' command first"
         )
-        return
+        sys_exit(1)
     args.func(args)
 
 


### PR DESCRIPTION
- `get_rules.py`: Unknown `--profile` arguments now log an error and return instead of crashing.
- `new_profile.py`: Target arguments are parsed as UUIDs and deduplicated into a set.
- `new_target.py`: Rule arguments are parsed as UUIDs and deduplicated into a set.
- `collector.py`: Repack subprocess failures are caught, the partial config cleaned up, and None returned instead of propagating an exception.
- `target_set.py`: Multiselect option value corrected from Target object to target.name string.
- `target_set.py`: Rules missing from the rule set are now skipped with a warning instead of raising a KeyError.
- `main.py`: Stale cache now exits with code 1 via sys_exit instead of silently returning